### PR TITLE
Update code snippet

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -11,7 +11,7 @@
   <button id="import">Import Data</button>
 
   <script>
-    const importer = flatfileImporter('<%= @token %>', {env: 'staging'})
+    const importer = flatfileImporter('<%= @token %>')
 
     importer.on('init', ({ batchId }) => {
       console.log(`Batch ${batchId} has been initialized.`)


### PR DESCRIPTION
As of [this PR](https://github.com/FlatFilers/sdk/pull/12/files), the FlatfileImporter no longer accepts an `option` param.

- [X] Removes { env: staging} from all code snippets